### PR TITLE
fix link error during install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TARS_WEB_HOST "172.16.8.227:3000")
 
 include_directories(/usr/local/tars/cpp/thirdparty/include)
 link_directories(/usr/local/tars/cpp/thirdparty/lib)
+link_directories(/lib/x86_64-linux-gnu)
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,4 +6,4 @@ project(GatewayServer)
 
 gen_server("tars" "GatewayServer")
 
-target_link_libraries(GatewayServer mysqlclient)
+target_link_libraries(GatewayServer mysqlclient dl)


### PR DESCRIPTION
Ubuntu18.04 下执行install.sh 安装报错，提示dlopen 等函数未定义
`                       ~~^~~~~~~~~~                                                                                                                                                            
/usr/local/tars/cpp/include/tup/Tars.h:1010:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]                                                                                 
     for (Int32 i = 0; i < size; ++i)                                                                                                                                              
                       ~~^~~~~~                                                                                                                                                                                      
[100%] Linking CXX executable ../bin/GatewayServer                                                                                                                                                                   
/usr/local/tars/cpp/thirdparty/lib/libmysqlclient.a(client_plugin.c.o): In function `do_add_plugin':                                                                                                                 
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:245: undefined reference to `dlclose'                                                                                     
/usr/local/tars/cpp/thirdparty/lib/libmysqlclient.a(client_plugin.c.o): In function `mysql_client_plugin_deinit':                                                                                                    
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:381: undefined reference to `dlclose'                                                               
/usr/local/tars/cpp/thirdparty/lib/libmysqlclient.a(client_plugin.c.o): In function `mysql_load_plugin_v':                                                                                                           
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:469: undefined reference to `dlopen'                                                                
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:497: undefined reference to `dlsym'                                                                                       
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:488: undefined reference to `dlerror'                                                                                     
/home/yifabao/go/src/github.com/TarsCloud/TarsCpp/src/mysql-lib/sql-common/client_plugin.c:500: undefined reference to `dlclose'                                                   
collect2: error: ld returned 1 exit status                                                                                                                                                                           
src/CMakeFiles/GatewayServer.dir/build.make:382: recipe for target 'bin/GatewayServer' failed                                                                                      
make[3]: *** [bin/GatewayServer] Error 1
CMakeFiles/Makefile2:351: recipe for target 'src/CMakeFiles/GatewayServer.dir/all' failed
make[2]: *** [src/CMakeFiles/GatewayServer.dir/all] Error 2
CMakeFiles/Makefile2:363: recipe for target 'src/CMakeFiles/GatewayServer.dir/rule' failed
make[1]: *** [src/CMakeFiles/GatewayServer.dir/rule] Error 2
Makefile:222: recipe for target 'GatewayServer' failed
make: *** [GatewayServer] Error 2
`

在cmake file 里添加了 dl 依赖，安装成功