### PR TITLE
Feat: add remote-ip in HttpBase

### DIFF
--- a/src/httpproxy/HttpBase.cpp
+++ b/src/httpproxy/HttpBase.cpp
@@ -99,6 +99,7 @@ int HttpBase::handleHttpRequest(shared_ptr<HandleParam> stParam, shared_ptr<Acce
     }
 
     stParam->httpRequest.setPath(rr.path.c_str());
+    stParam->httpRequest.setHeader("REMOTE_IP", stParam->sIP);
     TC_HttpAsync::RequestCallbackPtr cb = new AsyncHttpCallback(reqUrl, stParam->current, proxy, aLog, stParam->httpKeepAlive);
     _httpAsync.doAsyncRequest(stParam->httpRequest, cb, aLog->proxyAddr);
     TLOG_DEBUG("doAsyncHttpRequest, " << aLog->host << "/" << reqUrl << "=>" << aLog->proxyAddr << endl);


### PR DESCRIPTION
让http proxy代理的服务也可以通过 “REMOTE_IP”获取请求端IP地址。